### PR TITLE
Implement dashboard metrics retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,24 @@ This repository has examples of the following:
 
 4. Run the example with `npm run dev` or `yarn dev` and navigate to http://localhost:3000
 5. Once you get familiar with some of the flows, [brand your Authkit hosted page](https://workos.com/docs/user-management/branding)
+
+## Dashboard API Example
+
+Calling `/api/dashboard` returns metrics and a small sample of recent authentication events. Example response:
+
+```json
+{
+  "metrics": {
+    "totalUsers": 42,
+    "totalOrgs": 7,
+    "authEvents": 5
+  },
+  "recentActivity": [
+    {
+      "user": "user_01ABCD",
+      "action": "authentication.sso_succeeded",
+      "time": "2024-05-01T12:30:00.000Z"
+    }
+  ]
+}
+```

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -20,17 +20,37 @@ export async function GET() {
     // Get authentication events for the last 30 days
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-    
 
+    const eventsResponse = await workos.events.listEvents({
+      events: [
+        'authentication.oauth_succeeded',
+        'authentication.sso_succeeded',
+        'authentication.password_succeeded',
+        'authentication.magic_auth_succeeded',
+        'authentication.mfa_succeeded',
+      ],
+      rangeStart: thirtyDaysAgo.toISOString(),
+      limit: 50,
+    });
+
+    const authEvents = eventsResponse.data.length;
 
     // Get recent activity
-
+    const recentActivity = eventsResponse.data.slice(0, 5).map((event) => ({
+      user: (event.data && ('email' in event.data))
+        ? (event.data.email || event.data.userId || 'Unknown')
+        : 'Unknown',
+      action: event.event,
+      time: event.createdAt,
+    }));
 
     return NextResponse.json({
       metrics: {
         totalUsers,
         totalOrgs,
+        authEvents,
       },
+      recentActivity,
     });
   } catch (error) {
     console.error('Error fetching dashboard data:', error);


### PR DESCRIPTION
## Summary
- implement recent activity retrieval for dashboard API
- document the expected JSON in the README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68434361b230832b987eb9ca92045afb